### PR TITLE
Event overlap fix for colby

### DIFF
--- a/back-end/utils/misc.ts
+++ b/back-end/utils/misc.ts
@@ -197,10 +197,11 @@ export function checkInProgressEventOverlap(
     return false
   }
 
-  const start1 = newEvent.start_datetime
-  const start2 = existingEvent.start_datetime
-  const end1 = newEvent.end_datetime
-  const end2 = existingEvent.end_datetime
+  // Convert both events to UTC for consistent comparison
+  const start1 = newEvent.start_datetime.utc(true)
+  const start2 = existingEvent.start_datetime.utc(true)
+  const end1 = newEvent.end_datetime?.utc(true)
+  const end2 = existingEvent.end_datetime?.utc(true)
 
   if (!end1) {
     if (!end2) {


### PR DESCRIPTION
I _think_ this small change should fix this issue: https://github.com/vibecamp/vibecamp-web/issues/39

The fix here is to make sure both events are in UTC when they're compared.

I ran the current tests and they passed with this change.

(Side note: be aware that there appears to be a 15 minute buffer used in `checkInProgressEventOverlap` `front-end/src/components/events/EventEditor.tsx` line `135`, so e.g. an event running from say 12:00 pm - 1:00 pm will "overlap" with another running from e.g. 1:00 pm - 2:00 pm if it's on the same day and in same location.)