### PR TITLE
Hide cabins for jen

### DIFF
--- a/back-end/routes/v1/account.ts
+++ b/back-end/routes/v1/account.ts
@@ -15,15 +15,17 @@ import {
 } from '../../utils/validation.ts'
 import { passwordResetEmail, sendMail } from '../../utils/mailgun.ts'
 
-// We're hiding cabins for non-team members until the first day of the festival
+// Hiding cabins for non-team members until day before festival starts. Day
+// before instead of day of because this gets rid of risk of timezone issues
 const shouldShowCabinsForFestival = (festivalStartDate: Date, isTeamMember: boolean) => {
   if (isTeamMember) return true
-  
-  const festivalStart = new Date(festivalStartDate)
-  festivalStart.setHours(0, 0, 0, 0)
-  
+
+  const dayBefore = new Date(festivalStartDate)
+  dayBefore.setDate(dayBefore.getDate() - 1)
+  dayBefore.setHours(0, 0, 0, 0)
+
   const now = new Date()
-  return now >= festivalStart
+  return now >= dayBefore
 }
 
 export default function register(router: Router) {

--- a/back-end/routes/v1/event.ts
+++ b/back-end/routes/v1/event.ts
@@ -8,7 +8,7 @@ import { icsCalendar } from '../../utils/ics.ts'
 
 const UTC_OFFSET_MINUTES = dayjs().utcOffset()
 
-const stringifyDate = (date: Date) =>
+export const stringifyDate = (date: Date) =>
   dayjs.utc(date).add(UTC_OFFSET_MINUTES, 'minutes').toISOString()
 
 const stringifyStartAndEndDates = <T extends Tables['event']>(

--- a/back-end/utils/ics.ts
+++ b/back-end/utils/ics.ts
@@ -103,7 +103,7 @@ Deno.test({
         BEGIN:VCALENDAR
         VERSION:2.0
         PRODID:-//Vibecamp//Event Schedule//EN
-        X-WR-CALNAME: Vibecamp Event Schedule
+        X-WR-CALNAME:Vibecamp Event Schedule
         CALSCALE:GREGORIAN
         METHOD:PUBLISH
 


### PR DESCRIPTION
This hides cabins for festivals until the day before a festival. Day before instead of day of because this makes this code more timezone issues proof, in case an event is ever hosted at a time + location where midnight for the server is not soon enough for unhiding. I'm just making a quick judgment call here on the unhide date so of course feel free to update this as you see fit