### PR TITLE
Fix cabin assignments showing under wrong festivals

### DIFF
--- a/back-end/routes/v1/account.ts
+++ b/back-end/routes/v1/account.ts
@@ -75,8 +75,7 @@ export default function register(router: Router) {
             attendee_id: Tables['attendee']['attendee_id']
             festival_id: Tables['festival']['festival_id']
           }>`
-            select cabin.name as cabin_name, attendee.attendee_id, attendee.festival_id 
-            from attendee
+            select cabin.name as cabin_name, attendee.attendee_id, festival_id from attendee
             left join attendee_cabin on attendee.attendee_id = attendee_cabin.attendee_id
             left join cabin on attendee_cabin.cabin_id = cabin.cabin_id
             where attendee_cabin.cabin_id is not null and attendee.associated_account_id = ${account_id}

--- a/back-end/routes/v1/account.ts
+++ b/back-end/routes/v1/account.ts
@@ -75,12 +75,10 @@ export default function register(router: Router) {
             attendee_id: Tables['attendee']['attendee_id']
             festival_id: Tables['festival']['festival_id']
           }>`
-            select cabin.name as cabin_name, attendee.attendee_id, festival.festival_id 
+            select cabin.name as cabin_name, attendee.attendee_id, attendee.festival_id 
             from attendee
             left join attendee_cabin on attendee.attendee_id = attendee_cabin.attendee_id
             left join cabin on attendee_cabin.cabin_id = cabin.cabin_id
-            left join festival_site on cabin.festival_site_id = festival_site.festival_site_id
-            left join festival on festival.festival_site_id = festival_site.festival_site_id
             where attendee_cabin.cabin_id is not null and attendee.associated_account_id = ${account_id}
           `,
           festivals: db.queryTable('festival'),


### PR DESCRIPTION
Cabin assignments for upcoming festivals were incorrectly appearing under previous festivals when they shared the same site. This was caught by a user because they noticed a cabin assignment under VC3, which they did not attend, so they realized it was for VC4.

This happened because I goofed up some SQL in #41, which was an unnecessary change anyway, so this undoes that. The fix has us use attendee.festival_id instead of festival.festival_id, as was originally the case before PR #41 was merged a few days ago, and removes unnecessary joins that were also added in that PR.